### PR TITLE
Example for bump of plexus-build-api to 1.0.0

### DIFF
--- a/mock-binding-project/api/pom.xml
+++ b/mock-binding-project/api/pom.xml
@@ -11,9 +11,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.opendaylight.mdsal</groupId>
-    <artifactId>binding-parent</artifactId>
-    <version>13.0.4</version>
+    <groupId>org.opendaylight.yangtools</groupId>
+    <artifactId>binding-bundle-parent</artifactId>
+    <version>14.0.1-SNAPSHOT</version>
     <relativePath/>
   </parent>
 

--- a/mock-binding-project/artifacts/pom.xml
+++ b/mock-binding-project/artifacts/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opendaylight.odlparent</groupId>
     <artifactId>odlparent-lite</artifactId>
-    <version>13.1.3</version>
+    <version>14.0.1</version>
     <relativePath/>
   </parent>
 

--- a/mock-binding-project/features/features-mock-binding-project/pom.xml
+++ b/mock-binding-project/features/features-mock-binding-project/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opendaylight.odlparent</groupId>
     <artifactId>feature-repo-parent</artifactId>
-    <version>13.1.3</version>
+    <version>14.0.1</version>
     <relativePath/>
   </parent>
 

--- a/mock-binding-project/features/odl-mock-binding-project/pom.xml
+++ b/mock-binding-project/features/odl-mock-binding-project/pom.xml
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>9.0.4</version>
+                <version>10.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/mock-binding-project/features/parent/pom.xml
+++ b/mock-binding-project/features/parent/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>single-feature-parent</artifactId>
-        <version>13.1.3</version>
+        <version>14.0.1</version>
         <relativePath/>
     </parent>
 

--- a/mock-binding-project/features/pom.xml
+++ b/mock-binding-project/features/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opendaylight.odlparent</groupId>
     <artifactId>odlparent-lite</artifactId>
-    <version>13.1.3</version>
+    <version>14.0.1</version>
     <relativePath/>
   </parent>
 

--- a/mock-binding-project/impl/pom.xml
+++ b/mock-binding-project/impl/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.opendaylight.mdsal</groupId>
     <artifactId>binding-parent</artifactId>
-    <version>13.0.4</version>
+    <version>14.0.0-SNAPSHOT</version>
     <relativePath/>
   </parent>
 
@@ -32,7 +32,7 @@
           <dependency>
               <groupId>org.opendaylight.controller</groupId>
               <artifactId>controller-artifacts</artifactId>
-              <version>9.0.4</version>
+              <version>10.0.0-SNAPSHOT</version>
               <type>pom</type>
               <scope>import</scope>
           </dependency>

--- a/mock-binding-project/karaf/pom.xml
+++ b/mock-binding-project/karaf/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opendaylight.odlparent</groupId>
     <artifactId>karaf4-parent</artifactId>
-    <version>13.1.3</version>
+    <version>14.0.1</version>
     <relativePath/>
   </parent>
 

--- a/mock-binding-project/pom.xml
+++ b/mock-binding-project/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.opendaylight.odlparent</groupId>
     <artifactId>odlparent</artifactId>
-    <version>13.1.3</version>
+    <version>14.0.1</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
Example to test bump of plexus-build-api to 1.0.0.

Mainly correct working of yang-maven-plugin.

yang-maven-plugin generate Java classes based on provided YANG model.
Java classes are generated correctly after version bump.

On `mvn clean install` everything is generated.

When plugin is run from IDE -
- If classes are already generated and up to date nothing is
 generated again.
- If new YANG is added new classes are generated and existing classes
 are not generated again.
- If existing YANG is modified affected classes are generated and 
 unaffected are not generated again.

Same behavior with `mvn install`.