### PR TITLE
Fix Scandium SR2 controller version

### DIFF
--- a/mock-binding-project/impl/pom.xml
+++ b/mock-binding-project/impl/pom.xml
@@ -32,7 +32,7 @@
           <dependency>
               <groupId>org.opendaylight.controller</groupId>
               <artifactId>controller-artifacts</artifactId>
-              <version>10.0.4</version>
+              <version>10.0.9</version>
               <type>pom</type>
               <scope>import</scope>
           </dependency>


### PR DESCRIPTION
Fix Scandium SR2 controller version to 10.0.9.

Finally, we are adopting:
    - odlparent- 14.0.8
    - mdsal- 14.0.11
    - controller- 10.0.9