### PR TITLE
Update restconf version in README

### DIFF
--- a/mock-binding-project/README.md
+++ b/mock-binding-project/README.md
@@ -107,7 +107,7 @@ Add the dependency and rebuild the project:
  <dependency>
      <groupId>org.opendaylight.netconf</groupId>
      <artifactId>odl-restconf-nb</artifactId>
-     <version>8.0.3</version>
+     <version>8.0.7</version>
      <classifier>features</classifier>
      <type>xml</type>
      <scope>runtime</scope>


### PR DESCRIPTION
Since we have bumped to Scandium SR2 versions, bump restconf version in README as well to align correctly.